### PR TITLE
Update Partitioner with new imports

### DIFF
--- a/content/posts/2014-06-14-partitioning-by-constructor.markdown
+++ b/content/posts/2014-06-14-partitioning-by-constructor.markdown
@@ -107,7 +107,7 @@ by name, but we don't particularly want to have to remember that fact.
 Fortunately Shapeless's records make a nicer syntax super easy:
 
 ``` scala
-import shapeless._, record._
+import shapeless._, labelled.{field, FieldType}
 
 trait Partitioner[C <: Coproduct] extends DepFn1[List[C]] { type Out <: HList }
 


### PR DESCRIPTION
I found the imports don't work anymore for shapeless 2.2.5.